### PR TITLE
Issue-17: add url override to post block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Newsletter Builder` will be documented in this file.
 
+## 0.3.3 - 2023-11-10
+
+- Add URL override to post block
+
 ## 0.3.1 - 2023-11-08
 
 - Remove singleton pattern of Email Providers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `Newsletter Builder` will be documented in this file.
 
 ## 0.3.3 - 2023-11-10
 
-- Add URL override to post block
+- Add URL override attribute and slotfill to post block
 
 ## 0.3.1 - 2023-11-08
 

--- a/blocks/post/block.json
+++ b/blocks/post/block.json
@@ -77,6 +77,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"overrideUrl": {
+			"type": "string",
+			"default": ""
+		},
 		"number": {
 			"type": "number",
 			"default": null

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -12,6 +12,7 @@ import {
   PanelBody,
   PanelRow,
   Spinner,
+  TextControl,
 } from '@wordpress/components';
 
 /**
@@ -45,6 +46,7 @@ interface EditProps {
     overrideExcerpt?: string;
     overrideContent?: string;
     overrideByline?: string;
+    overrideUrl?: string,
     number?: number;
     smallerFont?: boolean;
   },
@@ -73,6 +75,7 @@ export default function Edit({
     overrideExcerpt,
     overrideContent,
     overrideByline,
+    overrideUrl,
     number,
     smallerFont,
   },
@@ -85,6 +88,7 @@ export default function Edit({
       overrideImage: 0,
       overrideExcerpt: '',
       overrideContent: '',
+      overrideUrl: '',
     });
   };
 
@@ -284,6 +288,18 @@ export default function Edit({
                   value={overrideImage ?? 0}
                   onUpdate={({ id }) => setAttributes({ overrideImage: id })}
                   onReset={() => setAttributes({ overrideImage: 0 })}
+                />
+              </PanelRow>
+            </PanelBody>
+            <PanelBody
+              title={__('Override URL', 'wp-newsletter-builder')}
+              initialOpen
+            >
+              <PanelRow>
+                <TextControl
+                  value={overrideUrl ?? ''}
+                  onChange={(newValue: string) => setAttributes({ overrideUrl: newValue })}
+                  type="url"
                 />
               </PanelRow>
             </PanelBody>

--- a/blocks/post/render.php
+++ b/blocks/post/render.php
@@ -17,6 +17,7 @@ if ( empty( $attributes['postId'] ) || ! $wp_newsletter_builder_block_post ) {
 }
 $wp_newsletter_builder_post_title = ! empty( $attributes['overrideTitle'] ) ? $attributes['overrideTitle'] : $wp_newsletter_builder_block_post->post_title;
 $wp_newsletter_builder_post_image = ! empty( $attributes['overrideImage'] ) ? $attributes['overrideImage'] : get_post_thumbnail_id( $wp_newsletter_builder_block_post->ID );
+$wp_newsletter_builder_post_url   = ! empty( $attributes['overrideUrl'] ) ? $attributes['overrideUrl'] : get_permalink( $wp_newsletter_builder_block_post->ID );
 $wp_newsletter_builder_excerpt    = ! empty( $attributes['overrideExcerpt'] ) ? $attributes['overrideExcerpt'] : $wp_newsletter_builder_block_post->post_excerpt;
 $wp_newsletter_builder_content    = $wp_newsletter_builder_block_post->post_content;
 preg_match_all( '/<p.*?<\/p>/iU', $wp_newsletter_builder_content, $matches );
@@ -50,7 +51,7 @@ $wp_newsletter_builder_img_sizes    = $attributes['imgSizes'] ?? '';
 		switch ( $wp_newsletter_builder_item ) {
 			case 'title':
 				?>
-					<a class="post__title-link" href="<?php echo esc_url( get_permalink( $wp_newsletter_builder_block_post->ID ) ); ?>">
+					<a class="post__title-link" href="<?php echo esc_url( $wp_newsletter_builder_post_url ); ?>">
 						<h2 class="<?php echo esc_attr( $wp_newsletter_builder_title_class ); ?>">
 							<?php if ( ! empty( $wp_newsletter_builder_number ) ) : ?>
 								<span class="newsletter-post__number"><?php echo esc_html( $wp_newsletter_builder_number ); ?>.</span>
@@ -82,7 +83,7 @@ $wp_newsletter_builder_img_sizes    = $attributes['imgSizes'] ?? '';
 			case 'image':
 				?>
 				<?php if ( $wp_newsletter_builder_showimage && ! empty( $wp_newsletter_builder_post_image ) ) : ?>
-					<a class="post__image-link" href="<?php echo esc_url( get_permalink( $wp_newsletter_builder_block_post->ID ) ); ?>">
+					<a class="post__image-link" href="<?php echo esc_url( $wp_newsletter_builder_post_url ); ?>">
 						<?php echo wp_get_attachment_image( $wp_newsletter_builder_post_image, 'full', false, [ 'sizes' => $wp_newsletter_builder_img_sizes ] ); ?>
 					</a>
 					<?php
@@ -109,11 +110,11 @@ $wp_newsletter_builder_img_sizes    = $attributes['imgSizes'] ?? '';
 				<?php if ( $wp_newsletter_builder_showcta ) : ?>
 					<div class="wp-block-button has-text-align-center">
 						<!--[if mso]>
-						<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="<?php echo esc_url( get_permalink( $wp_newsletter_builder_block_post->ID ) ); ?>" style="height:48px;v-text-anchor:middle;width:200px;" arcsize="10%" stroke="f" fillcolor="#D62827">
+						<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="<?php echo esc_url( $wp_newsletter_builder_post_url ); ?>" style="height:48px;v-text-anchor:middle;width:200px;" arcsize="10%" stroke="f" fillcolor="#D62827">
 							<w:anchorlock/>
 							<center>
 						<![endif]-->
-						<a class="wp-element-button" href="<?php echo esc_url( get_permalink( $wp_newsletter_builder_block_post->ID ) ); ?>">
+						<a class="wp-element-button" href="<?php echo esc_url( $wp_newsletter_builder_post_url ); ?>">
 							<?php esc_html_e( 'Read More', 'wp-newsletter-builder' ); ?>
 						</a>
 						<!--[if mso]>

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.3.2
+ * Version: 0.3.3
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 5.9


### PR DESCRIPTION
### Description

This PR adds a URL override feature to the Post block, allowing users to specify a custom URL with analytics tracking parameters, etc. The override is stored in attributes and used on the front end instead of the post URL.

Related to Issue #17: [add url override to post block](https://github.com/alleyinteractive/wp-newsletter-builder/issues/17)

### Changes

- Added a new attribute for storing the URL override
- Modified the Post block to use the URL override if provided
- Updated frontend rendering to use the URL override if available

### Testing

1. Create a new Post block and add a custom URL in the URL override field
2. Verify that the custom URL is used on the frontend instead of the post URL
3. Verify that the custom URL is properly saved in attributes
4. Remove the custom URL and verify that the post URL is used on the frontend instead
