### PR TITLE
Issue-39: Allow post display options to be edited without a post being selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Newsletter Builder` will be documented in this file.
 
+## 0.3.4 - 2023-11-13
+
+- Allow editing of post block attributes with no block selected. Allow order attribute to be edited.
+
 ## 0.3.3 - 2023-11-10
 
 - Add URL override attribute and slotfill to post block

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.3.3
+ * Version: 0.3.4
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 5.9


### PR DESCRIPTION
### Pull Request Title

Allow post display options to be edited without a post being selected (#39)

### Description

This pull request addresses the issue "Allow post display options to be edited without a post being selected" (#39). The changes made in this PR will make the items under the Post section of the sidebar visible even if a post is not selected in the Newsletter Single Post block. Additionally, the checkboxes will now be draggable, enabling users to set the "order" attribute.

### Issue Number

Closes #39

### Related Issue URL

https://github.com/alleyinteractive/wp-newsletter-builder/issues/39

### Notes

- Please test the changes made in this PR to ensure they work as expected.
- Ensure that the post display options can be edited without a post being selected.
- Verify that the draggable checkboxes for setting the "order" attribute work and are only enabled on the Template post type.
- Review the code changes made in this PR to guarantee they follow best practices.
