### PR TITLE
Adds placeholder for header image

### DIFF
--- a/blocks/header/edit.tsx
+++ b/blocks/header/edit.tsx
@@ -50,7 +50,7 @@ export default function Edit() {
     <div {...useBlockProps()}>
       {imageUrl ? (
         <img src={imageUrl} alt={__('Header', 'wp-newsletter-builder')} />
-      ) : null }
+      ) : <div className="wp-block-wp-newsletter-builder-header__placeholder">{__('Newsletter Header', 'wp-newsletter-builder')}</div> }
     </div>
   );
 }

--- a/blocks/header/style.scss
+++ b/blocks/header/style.scss
@@ -15,4 +15,12 @@
   margin-bottom: 20px;
   margin-top: 6px;
   // @TODO: style alt text.
+
+  &__placeholder {
+    align-items: center;
+    aspect-ratio: 16/9;
+    border: 1px dashed #000;
+    display: flex;
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
This adds a placeholder for the image in the block's `edit.tsx` file. It will only show if there's no image selected. I gave it a dashed border to make look like an obvious placeholder, and just centered the name of the block inside of it.