### PR TITLE
Issue-113: Update WordPress Fieldmanager and remove unnecessary instances of `@phpstan-ignore-next-line the Fieldmanager doc block is incorrect.`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Newsletter Builder` will be documented in this file.
 
+## 0.3.10 - 2024-05-06
+
+- Removes instances of `@phpstan-ignore-next-line the Fieldmanager doc block is incorrect` which are unnecessary now that WordPress Fieldmanager is doc blocks have been updated
+
 ## 0.3.9 - 2024-05-06
 
 - Adds `wp_newsletter_builder_allowed_post_types` filter for filtering post types that appear in the post picker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `Newsletter Builder` will be documented in this file.
 
 ## 0.3.10 - 2024-05-06
 
-- Removes instances of `@phpstan-ignore-next-line the Fieldmanager doc block is incorrect` which are unnecessary now that WordPress Fieldmanager is doc blocks have been updated
+- Removes instances of `@phpstan-ignore-next-line the Fieldmanager doc block is incorrect` which are unnecessary now that WordPress Fieldmanager doc blocks have been updated
 
 ## 0.3.9 - 2024-05-06
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For example, to allow a custom `podcast` post type to appear in the post picker,
 
 ```php
 add_filter( 'wp_newsletter_builder_allowed_post_types',
-	function( array $allowed_post_types ) {
+  function( array $allowed_post_types ) {
     $allowed_post_types[] = 'podcast';
     return $allowed_post_types;
   }

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.3.9
+ * Version: 0.3.10
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 6.2

--- a/src/class-breaking-recipients.php
+++ b/src/class-breaking-recipients.php
@@ -46,13 +46,11 @@ class Breaking_Recipients {
 	 */
 	public function register_fields(): void {
 		$settings = new \Fieldmanager_Group(
-			// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 			[
 				'name'           => static::SETTINGS_KEY,
 				'label'          => __( 'List', 'wp-newsletter-builder' ),
 				'children'       => [
 					'list' => new \Fieldmanager_Autocomplete(
-						// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 						[
 							'datasource' => new \Fieldmanager_Datasource(
 								[

--- a/src/class-email-types.php
+++ b/src/class-email-types.php
@@ -49,7 +49,6 @@ class Email_Types {
 		$plugin_settings = new Settings();
 		$from_names      = $plugin_settings->get_from_names();
 		$settings        = new \Fieldmanager_Group(
-			// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 			[
 				'name'           => static::SETTINGS_KEY,
 				'children'       => [
@@ -67,7 +66,6 @@ class Email_Types {
 					},
 					'label'      => new \Fieldmanager_TextField( __( 'Label', 'wp-newsletter-builder' ) ),
 					'image'      => new \Fieldmanager_Media(
-						// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 						[
 							'label'        => __( 'Image', 'wp-newsletter-builder' ),
 							'preview_size' => 'full',
@@ -95,7 +93,6 @@ class Email_Types {
 						]
 					),
 					'safe_rtb'   => new \Fieldmanager_TextArea(
-						// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 						[
 							'label'    => __( 'SafeRTB Ad Tag', 'wp-newsletter-builder' ),
 							'sanitize' => function ( $value ) {
@@ -104,12 +101,10 @@ class Email_Types {
 						],
 					),
 					'ad_tags'    => new \Fieldmanager_Group(
-						// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 						[
 							'label'          => __( 'Tags', 'wp-newsletter-builder' ),
 							'children'       => [
 								'tag_code' => new \Fieldmanager_TextArea(
-									// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 									[
 										'label'    => __( 'Ad Tag', 'wp-newsletter-builder' ),
 										'sanitize' => function ( $value ) {
@@ -123,24 +118,20 @@ class Email_Types {
 						]
 					),
 					'roadblock'  => new \Fieldmanager_Checkbox(
-						// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 						[
 							'label' => __( 'Enable Ad Roadblock', 'wp-newsletter-builder' ),
 						]
 					),
 					'key_values' => new \Fieldmanager_Group(
-						// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 						[
 							'label'              => __( 'Key/Value Pairs', 'wp-newsletter-builder' ),
 							'children'           => [
 								'key'   => new \Fieldmanager_TextField(
-									// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 									[
 										'label' => __( 'Key', 'wp-newsletter-builder' ),
 									]
 								),
 								'value' => new \Fieldmanager_TextField(
-									// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 									[
 										'label' => __( 'Value', 'wp-newsletter-builder' ),
 									]

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -51,7 +51,6 @@ class Settings {
 				'from_email'      => new \Fieldmanager_TextField( __( 'From Email', 'wp-newsletter-builder' ) ),
 				'reply_to_email'  => new \Fieldmanager_TextField( __( 'Reply To Email', 'wp-newsletter-builder' ) ),
 				'from_names'      => new \Fieldmanager_TextField(
-					// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 					[
 						'label'              => __( 'From Names', 'wp-newsletter-builder' ),
 						'limit'              => 0,
@@ -60,45 +59,38 @@ class Settings {
 					]
 				),
 				'footer_settings' => new \Fieldmanager_Group(
-					// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 					[
 						'label'       => __( 'Footer Settings', 'wp-newsletter-builder' ),
 						'collapsed'   => true,
 						'collapsible' => true,
 						'children'    => [
 							'facebook_url'  => new \Fieldmanager_Link(
-								// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 								[
 									'label' => __( 'Facebook URL', 'wp-newsletter-builder' ),
 								]
 							),
 							'twitter_url'   => new \Fieldmanager_Link(
-								// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 								[
 									'label' => __( 'Twitter URL', 'wp-newsletter-builder' ),
 								]
 							),
 							'instagram_url' => new \Fieldmanager_Link(
-								// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 								[
 									'label' => __( 'Instagram URL', 'wp-newsletter-builder' ),
 								]
 							),
 							'youtube_url'   => new \Fieldmanager_Link(
-								// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 								[
 									'label' => __( 'YouTube URL', 'wp-newsletter-builder' ),
 								]
 							),
 							'image'         => new \Fieldmanager_Media(
-								// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 								[
 									'label'        => __( 'Footer Image', 'wp-newsletter-builder' ),
 									'preview_size' => 'medium',
 								]
 							),
 							'address'       => new \Fieldmanager_TextField(
-								// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 								[
 									'label' => __( 'Company Address', 'wp-newsletter-builder' ),
 								]

--- a/src/email-providers/class-campaign-monitor.php
+++ b/src/email-providers/class-campaign-monitor.php
@@ -46,7 +46,6 @@ class Campaign_Monitor implements Email_Provider {
 	 */
 	public function register_fields(): void {
 		$settings = new \Fieldmanager_Group(
-			// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 			[
 				'name'     => static::SETTINGS_KEY,
 				'children' => [

--- a/src/email-providers/class-sendgrid.php
+++ b/src/email-providers/class-sendgrid.php
@@ -50,7 +50,6 @@ class Sendgrid implements Email_Provider {
 	 */
 	public function register_fields(): void {
 		$settings = new \Fieldmanager_Group(
-			// @phpstan-ignore-next-line the Fieldmanager doc block is incorrect.
 			[
 				'name'     => static::SETTINGS_KEY,
 				'children' => [


### PR DESCRIPTION
## Summary
This pull request updates the WordPress Fieldmanager dependency for WP Newsletter Builder and removes all unnecessary instances of `@phpstan-ignore-next-line the Fieldmanager doc block is incorrect.` as discussed in the issue. Fixes #113

## Description
WordPress Fieldmanager is a dependency of WP Newsletter Builder.

While implementing phpstan in #31, we noticed that there were phpstan errors around the `$label` parameter in Fieldmanager class constructors, which can be either a `string` or an `array`, but the doc block only indicated that it could be a `string`.

The issue at https://github.com/alleyinteractive/wordpress-fieldmanager/pull/869 would update the Fieldmanager doc blocks.

Once that issue is fixed and a new release of WordPress Fieldmanager is created, we should update WP Newsletter Builder to use that new release, and remove all instances of `@phpstan-ignore-next-line the Fieldmanager doc block is incorrect.` in the WP Newsletter Builder code.

## Use Case
When a developer is working on WP Newsletter Builder they should have the most up to date version of WordPress Fieldmanager so that we can remove `phpstan-ignore` lines.
