### PR TITLE
Issue-36: Add filter to specify which post types can be selected in Newsletter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `Newsletter Builder` will be documented in this file.
 
 ## 0.3.9 - 2024-05-06
 
-- Adds `wpNewsletterBuilder.allowedPostTypes` filter for filtering post types that appear in the post picker
+- Adds `wp_newsletter_builder_allowed_post_types` filter for filtering post types that appear in the post picker
 
 ## 0.3.8 - 2024-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Newsletter Builder` will be documented in this file.
 
+## 0.3.9 - 2024-05-06
+
+- Adds `wpNewsletterBuilder.allowedPostTypes` filter for filtering post types that appear in the post picker
+
 ## 0.3.8 - 2024-04-29
 
 - Update dependencies, bump PHP version to 8.1

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For example, to allow a custom `podcast` post type to appear in the post picker,
 ```php
 add_filter( 'wp_newsletter_builder_allowed_post_types',
 	function( array $allowed_post_types ) {
-    $allowed_post_types[] = 'page';
+    $allowed_post_types[] = 'podcast';
     return $allowed_post_types;
   }
 );

--- a/README.md
+++ b/README.md
@@ -64,14 +64,12 @@ The plugin allows filtering of post types available in the Gutenberg post picker
 
 For example, to allow a custom `podcast` post type to appear in the post picker, along with the default `post` post type:
 
-```javascript
-addFilter(
-  'wpNewsletterBuilder.allowedPostTypes',
-  'wp-newsletter-builder/post-picker',
-  (allowedPostTypes: string[]) => {
-    allowedPostTypes.push('podcast');
-    return allowedPostTypes;
-  },
+```php
+add_filter( 'wp_newsletter_builder_allowed_post_types',
+	function( array $allowed_post_types ) {
+    $allowed_post_types[] = 'page';
+    return $allowed_post_types;
+  }
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ add_filter( 'wp_newsletter_builder_selected_provider',
 	fn( $provider ) => 'WP_Newsletter_Builder\Email_Providers\PROVIDER'
 );
 ```
+### Filtering Post Types Available in the Post Picker
+
+The plugin allows filtering of post types available in the Gutenberg post picker. The post picker appears in the `wp-newsletter-builder/post` block as a single post picker and in the `wp-newsletter-builder/section` block as a multiple post picker.
+
+For example, to allow a custom `podcast` post type to appear in the post picker, along with the default `post` post type:
+
+```javascript
+addFilter(
+  'wpNewsletterBuilder.allowedPostTypes',
+  'wp-newsletter-builder/post-picker',
+  (allowedPostTypes: string[]) => {
+    allowedPostTypes.push('podcast');
+    return allowedPostTypes;
+  },
+);
+```
 
 ## Testing
 

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -12,6 +12,7 @@ import {
   PanelRow,
   TextControl,
 } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * React hook that is used to mark the block wrapper element.
@@ -106,7 +107,7 @@ export default function Edit({
           {/* @ts-ignore */}
           <PostPicker
             onUpdate={handleSelect}
-            allowedTypes={['post']}
+            allowedTypes={applyFilters('wpNewsletterBuilder.allowedPostTypes') as string[] ?? ['post']} // Allow filtering of allowed post types.
             onReset={() => handleSelect(0)}
             params={{ after: cutoff.toISOString(), per_page: 20 }}
             title={__('Please select a post', 'wp-newsletter-builder')}

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -12,7 +12,6 @@ import {
   PanelRow,
   TextControl,
 } from '@wordpress/components';
-import { applyFilters } from '@wordpress/hooks';
 
 /**
  * React hook that is used to mark the block wrapper element.
@@ -38,6 +37,19 @@ interface EditProps {
   },
   setAttributes: (attributes: {}) => void;
 }
+
+// Allow filtering of allowed post types. Defaults to post.
+interface Window {
+  newsletterBuilder: {
+    allowedPostTypes: Array<string>;
+  };
+}
+
+const {
+  newsletterBuilder: {
+    allowedPostTypes = ['post'],
+  } = {},
+} = (window as any as Window);
 
 /**
  * The edit function describes the structure of your block in the context of the
@@ -107,7 +119,7 @@ export default function Edit({
           {/* @ts-ignore */}
           <PostPicker
             onUpdate={handleSelect}
-            allowedTypes={applyFilters('wpNewsletterBuilder.allowedPostTypes', ['post']) as string[]} // Allow filtering of allowed post types. Defaults to post.
+            allowedTypes={allowedPostTypes}
             onReset={() => handleSelect(0)}
             params={{ after: cutoff.toISOString(), per_page: 20 }}
             title={__('Please select a post', 'wp-newsletter-builder')}

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -107,7 +107,7 @@ export default function Edit({
           {/* @ts-ignore */}
           <PostPicker
             onUpdate={handleSelect}
-            allowedTypes={applyFilters('wpNewsletterBuilder.allowedPostTypes') as string[] ?? ['post']} // Allow filtering of allowed post types.
+            allowedTypes={applyFilters('wpNewsletterBuilder.allowedPostTypes', ['post']) as string[]} // Allow filtering of allowed post types. Defaults to post.
             onReset={() => handleSelect(0)}
             params={{ after: cutoff.toISOString(), per_page: 20 }}
             title={__('Please select a post', 'wp-newsletter-builder')}

--- a/blocks/section/edit.tsx
+++ b/blocks/section/edit.tsx
@@ -8,6 +8,7 @@ import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 import MultiplePostPicker from '@/components/multiplePostPicker';
 import PostPickerResult from '@/components/postPickerResult';
@@ -118,7 +119,7 @@ export default function Edit({
           <PanelRow>
             <MultiplePostPicker
               onUpdate={handleSelect}
-              allowedTypes={['post']}
+              allowedTypes={applyFilters('wpNewsletterBuilder.allowedPostTypes', ['post']) as string[]} // Allow filtering of allowed post types. Defaults to post.
               params={{ after: cutoff.toISOString(), per_page: 20 }}
               // @ts-ignore
               searchRender={PostPickerResult}

--- a/blocks/section/edit.tsx
+++ b/blocks/section/edit.tsx
@@ -8,7 +8,6 @@ import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
-import { applyFilters } from '@wordpress/hooks';
 
 import MultiplePostPicker from '@/components/multiplePostPicker';
 import PostPickerResult from '@/components/postPickerResult';

--- a/blocks/section/edit.tsx
+++ b/blocks/section/edit.tsx
@@ -33,6 +33,19 @@ export interface Block {
   }
 }
 
+// Allow filtering of allowed post types. Defaults to post.
+interface Window {
+  newsletterBuilder: {
+    allowedPostTypes: Array<string>;
+  };
+}
+
+const {
+  newsletterBuilder: {
+    allowedPostTypes = ['post'],
+  } = {},
+} = (window as any as Window);
+
 /**
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
@@ -119,7 +132,7 @@ export default function Edit({
           <PanelRow>
             <MultiplePostPicker
               onUpdate={handleSelect}
-              allowedTypes={applyFilters('wpNewsletterBuilder.allowedPostTypes', ['post']) as string[]} // Allow filtering of allowed post types. Defaults to post.
+              allowedTypes={allowedPostTypes}
               params={{ after: cutoff.toISOString(), per_page: 20 }}
               // @ts-ignore
               searchRender={PostPickerResult}

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.3.8
+ * Version: 0.3.9
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 6.2

--- a/src/assets.php
+++ b/src/assets.php
@@ -137,6 +137,14 @@ function action_enqueue_block_editor_assets(): void {
 		$uses_suppression_lists = $newsletter_builder_email_provider->uses_suppression_lists();
 	}
 
+	/**
+	 * Allow filtering of allowed post types available in the post picker.
+	 * 
+	 * @param array<string> $allowed_post_types The allowed post types. Defaults to `post`.
+	 * @return array<string> The filtered array of allowed post types.
+	 */
+	$allowed_post_types = apply_filters('wp_newsletter_builder_allowed_post_types', ['post'] );
+
 	wp_localize_script(
 		'wp-newsletter-builder-email-settings-editor-script',
 		'newsletterBuilder',
@@ -144,6 +152,7 @@ function action_enqueue_block_editor_assets(): void {
 			'fromNames'            => $settings->get_from_names(),
 			'templates'            => $template_map,
 			'usesSuppressionLists' => $uses_suppression_lists,
+			'allowedPostTypes'     => $allowed_post_types,
 		]
 	);
 }

--- a/src/assets.php
+++ b/src/assets.php
@@ -143,7 +143,7 @@ function action_enqueue_block_editor_assets(): void {
 	 * @param array<string> $allowed_post_types The allowed post types. Defaults to `post`.
 	 * @return array<string> The filtered array of allowed post types.
 	 */
-	$allowed_post_types = apply_filters('wp_newsletter_builder_allowed_post_types', ['post'] );
+	$allowed_post_types = apply_filters( 'wp_newsletter_builder_allowed_post_types', [ 'post' ] );
 
 	wp_localize_script(
 		'wp-newsletter-builder-email-settings-editor-script',


### PR DESCRIPTION
### Summary

This pull request adds the functionality to specify which post types show up in the Post Selector and Multi Post Selector via a filter, addressing the need for sites to include custom post types like Podcast episodes in their newsletters. Fixes #36

### Changes

- Implement a filter to allow specification of post types in the Post Selector and Multi Post Selector.

### Test Plan

- Verify that the filter correctly alters the available post types in the Post Selector and Multi Post Selector.
- Ensure that custom post types can be included and work as expected.

### Additional Notes

- This enhancement was requested to improve the flexibility of the Newsletter builder, allowing for a broader range of content types to be included in newsletters.
