### PR TITLE
Issue-122: Disable editor styles on nb_newsletter edit screen

### DIFF
--- a/src/assets.php
+++ b/src/assets.php
@@ -275,6 +275,13 @@ function load_scripts(): void {
 
 load_scripts();
 
+/**
+ * Remove the editor styles on the post edit screen for nb_newsletter post types.
+ *
+ * @param string $path The path to the file.
+ * @param string $file The file name.
+ * @return string|null The path to the file or null if we're on the post edit screen for a nb_newsletter post type.
+ */
 function remove_editor_styles_on_newsletters( $path, $file ) {
 	// If we're on the post edit screen for a nb_newsletter post type, remove the editor styles.
 	if ( is_admin() && 'nb_newsletter' === get_post_type() && 'theme.json' === $file ) {

--- a/src/assets.php
+++ b/src/assets.php
@@ -139,7 +139,7 @@ function action_enqueue_block_editor_assets(): void {
 
 	/**
 	 * Allow filtering of allowed post types available in the post picker.
-	 * 
+	 *
 	 * @param array<string> $allowed_post_types The allowed post types. Defaults to `post`.
 	 * @return array<string> The filtered array of allowed post types.
 	 */
@@ -274,3 +274,13 @@ function load_scripts(): void {
 }
 
 load_scripts();
+
+function remove_editor_styles_on_newsletters( $path, $file ) {
+	// If we're on the post edit screen for a nb_newsletter post type, remove the editor styles.
+	if ( is_admin() && 'nb_newsletter' === get_post_type() && 'theme.json' === $file ) {
+		return null;
+	}
+	return $path;
+}
+
+add_filter( 'theme_file_path', __NAMESPACE__ . '\remove_editor_styles_on_newsletters', 10, 2 );


### PR DESCRIPTION
### Summary
Fixes #122 - Disable editor styles on nb_newsletter edit screen

### Description
Styles from theme.json are overriding the newsletter styles in the editor, but they don't apply to the front end. The commit removes these editor styles to ensure consistency between the editor view and the front-end display.

### Steps To Reproduce
1. Use a theme with theme.json (like twenty twenty-three)
2. You should see extra styles, like the font style and size on headline.

### Additional Information
_No response_