### PR TITLE
LEDE-2612 Additional WordPress clean up

### DIFF
--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -21,7 +21,6 @@ import {
  */
 import { useBlockProps, InspectorControls, InnerBlocks } from '@wordpress/block-editor';
 
-import PostPickerResult from '@/components/postPickerResult';
 /**
  * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
  * Those files can contain any CSS code that gets applied to the editor.
@@ -121,8 +120,6 @@ export default function Edit({
             params={{ per_page: 20 }}
             title={__('Please select a post', 'wp-newsletter-builder')}
             value={postId}
-            // @ts-ignore
-            searchRender={PostPickerResult}
           />
         </div>
       ) : null}

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -78,9 +78,6 @@ export default function Edit({
     [],
   );
 
-  const cutoff = new Date();
-  cutoff.setMonth(cutoff.getMonth() - 3);
-
   // TODO: Pass template and allowed blocks from PHP so they can be filtered.
   const MY_TEMPLATE = [
     ['wp-newsletter-builder/post-featured-image', {}],
@@ -121,7 +118,7 @@ export default function Edit({
             onUpdate={handleSelect}
             allowedTypes={allowedPostTypes}
             onReset={() => handleSelect(0)}
-            params={{ after: cutoff.toISOString(), per_page: 20 }}
+            params={{ per_page: 20 }}
             title={__('Please select a post', 'wp-newsletter-builder')}
             value={postId}
             // @ts-ignore

--- a/blocks/post/style.scss
+++ b/blocks/post/style.scss
@@ -63,4 +63,8 @@
   table {
     width: 100%;
   }
+
+  li {
+    font-size: 16px;
+  }
 }

--- a/components/postPickerResult/index.scss
+++ b/components/postPickerResult/index.scss
@@ -2,7 +2,6 @@
   .alley-scripts-post-picker__post-list .alley-scripts-post-picker__post {
     height: auto;
     padding: 0 5px 0 0;
-    width: 99%;
   }
 
   .nb-post-picker-result {

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.3.12
+ * Version: 0.3.13
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 6.2

--- a/scss/core-blocks/list.scss
+++ b/scss/core-blocks/list.scss
@@ -1,3 +1,4 @@
 li {
-  font-family: Geogria, serif;
+  font-family: Georgia, serif;
+  font-size: 16px;
 }

--- a/src/class-email-types.php
+++ b/src/class-email-types.php
@@ -52,7 +52,7 @@ class Email_Types {
 			[
 				'name'           => static::SETTINGS_KEY,
 				'children'       => [
-					'uuid4'      => new class() extends \Fieldmanager_Hidden {
+					'uuid4'     => new class() extends \Fieldmanager_Hidden {
 						/**
 						 * Ensure that each group has a unique ID.
 						 *
@@ -64,14 +64,14 @@ class Email_Types {
 							return $current_value ?: wp_generate_uuid4();
 						}
 					},
-					'label'      => new \Fieldmanager_TextField( __( 'Label', 'wp-newsletter-builder' ) ),
-					'image'      => new \Fieldmanager_Media(
+					'label'     => new \Fieldmanager_TextField( __( 'Label', 'wp-newsletter-builder' ) ),
+					'image'     => new \Fieldmanager_Media(
 						[
 							'label'        => __( 'Image', 'wp-newsletter-builder' ),
 							'preview_size' => 'full',
 						]
 					),
-					'templates'  => new \Fieldmanager_Checkboxes(
+					'templates' => new \Fieldmanager_Checkboxes(
 						'Checkboxes',
 						[
 							'datasource' => new \Fieldmanager_Datasource_Post(
@@ -86,7 +86,7 @@ class Email_Types {
 							),
 						]
 					),
-					'from_name'  => new \Fieldmanager_Select(
+					'from_name' => new \Fieldmanager_Select(
 						__( 'From Name', 'wp-newsletter-builder' ),
 						[
 							'options' => $from_names,

--- a/src/class-email-types.php
+++ b/src/class-email-types.php
@@ -92,56 +92,6 @@ class Email_Types {
 							'options' => $from_names,
 						]
 					),
-					'safe_rtb'   => new \Fieldmanager_TextArea(
-						[
-							'label'    => __( 'SafeRTB Ad Tag', 'wp-newsletter-builder' ),
-							'sanitize' => function ( $value ) {
-								return $value;
-							},
-						],
-					),
-					'ad_tags'    => new \Fieldmanager_Group(
-						[
-							'label'          => __( 'Tags', 'wp-newsletter-builder' ),
-							'children'       => [
-								'tag_code' => new \Fieldmanager_TextArea(
-									[
-										'label'    => __( 'Ad Tag', 'wp-newsletter-builder' ),
-										'sanitize' => function ( $value ) {
-											return $value;
-										},
-									],
-								),
-							],
-							'limit'          => 0,
-							'add_more_label' => __( 'Add another tag', 'wp-newsletter-builder' ),
-						]
-					),
-					'roadblock'  => new \Fieldmanager_Checkbox(
-						[
-							'label' => __( 'Enable Ad Roadblock', 'wp-newsletter-builder' ),
-						]
-					),
-					'key_values' => new \Fieldmanager_Group(
-						[
-							'label'              => __( 'Key/Value Pairs', 'wp-newsletter-builder' ),
-							'children'           => [
-								'key'   => new \Fieldmanager_TextField(
-									[
-										'label' => __( 'Key', 'wp-newsletter-builder' ),
-									]
-								),
-								'value' => new \Fieldmanager_TextField(
-									[
-										'label' => __( 'Value', 'wp-newsletter-builder' ),
-									]
-								),
-							],
-							'limit'              => 0,
-							'add_more_label'     => __( 'Add another key/value pair', 'wp-newsletter-builder' ),
-							'one_label_per_item' => false,
-						]
-					),
 				],
 				'limit'          => 0,
 				'add_more_label' => __( 'Add Another Email Type', 'wp-newsletter-builder' ),


### PR DESCRIPTION
## Summary
Additional Newsletter Builder cleanup - restores default layout to post picker, removes ad-related fields from the Email Types section, and fixes list item styles

## Notes for reviewers
* Version bump
* Added issue #125 

## Ticket
https://alleyinteractive.atlassian.net/browse/LEDE-2615