### PR TITLE
LEDE-2615 Even More WordPress cleanup

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.3.13
+ * Version: 0.3.14
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 6.2

--- a/plugin.php
+++ b/plugin.php
@@ -64,7 +64,6 @@ global $newsletter_builder_email_provider;
 function main(): void {
 	new Ads();
 	new Block_Modifications();
-	new Breaking_Recipients();
 	new Email_Types();
 	new Settings();
 	new Media();

--- a/src/class-email-types.php
+++ b/src/class-email-types.php
@@ -72,7 +72,7 @@ class Email_Types {
 						]
 					),
 					'templates' => new \Fieldmanager_Checkboxes(
-						'Checkboxes',
+						'Templates',
 						[
 							'datasource' => new \Fieldmanager_Datasource_Post(
 								[

--- a/src/class-wp-newsletter-builder.php
+++ b/src/class-wp-newsletter-builder.php
@@ -307,6 +307,7 @@ class WP_Newsletter_Builder {
 		if (
 			$query->is_main_query()
 			&& isset( $query->query_vars['post_type'] )
+			&& ! $query->is_admin
 			&& 'nb_newsletter' === $query->query_vars['post_type']
 		) {
 			$query->query['post_status']      = [ 'publish', 'draft' ];


### PR DESCRIPTION
## Summary
Additional Newsletter Builder cleanup -  changes `Checkboxes` label to `Templates`, removes Breaking Recipients from the Newsletter Builder menu, and adds Greg's fix for scheduling emails.

## Notes for reviewers
* Version bump
* Added issue #131 

## Ticket
https://alleyinteractive.atlassian.net/browse/LEDE-2615