### PR TITLE
LEDE-2616: Header and Footer Enhancements

### DIFF
--- a/blocks/footer/edit.tsx
+++ b/blocks/footer/edit.tsx
@@ -142,11 +142,9 @@ export default function Edit({
           </>
         )}
       <div className="wp-block-wp-newsletter-builder-footer__links">
-        {/* @ts-ignore */}
-        <preferences>{__('Preferences', 'wp-newsletter-builder')}</preferences>
-        {' | '}
-        {/* @ts-ignore */}
-        <unsubscribe>{__('Unsubscribe', 'wp-newsletter-builder')}</unsubscribe>
+        <a href="#unsubscribe_preferences">
+          {__('Manage Subscription Preferences', 'wp-newsletter-builder')}
+        </a>
       </div>
     </div>
   );

--- a/blocks/footer/render.php
+++ b/blocks/footer/render.php
@@ -70,8 +70,6 @@ $nb_separator_class  = $nb_narrow_separator ? '' : 'is-style-wide';
 	<?php endif; ?>
 
 	<div class="wp-block-wp-newsletter-builder-footer__links">
-		<a href="#unsubscribe"><?php esc_html_e( 'Unsubscribe', 'wp-newsletter-builder' ); ?></a>
-		&nbsp;|&nbsp;
-		<a href="#unsubscribe_preferences"><?php esc_html_e( 'Preferences', 'wp-newsletter-builder' ); ?></a>
+		<a href="#unsubscribe_preferences"><?php esc_html_e( 'Manage Subscription Preferences', 'wp-newsletter-builder' ); ?></a>
 	</div>
 </div>

--- a/blocks/footer/render.php
+++ b/blocks/footer/render.php
@@ -70,8 +70,8 @@ $nb_separator_class  = $nb_narrow_separator ? '' : 'is-style-wide';
 	<?php endif; ?>
 
 	<div class="wp-block-wp-newsletter-builder-footer__links">
-		<preferences><u><?php esc_html_e( 'Preferences', 'wp-newsletter-builder' ); ?></u></preferences>
+		<a href="{{unsubscribe}}"><?php esc_html_e( 'Unsubscribe', 'wp-newsletter-builder' ); ?></a>
 		&nbsp;|&nbsp;
-		<unsubscribe><u><?php esc_html_e( 'Unsubscribe', 'wp-newsletter-builder' ); ?></u></unsubscribe>
+		<a href="{{unsubscribe_preferences}}"><?php esc_html_e( 'Preferences', 'wp-newsletter-builder' ); ?></a>
 	</div>
 </div>

--- a/blocks/footer/render.php
+++ b/blocks/footer/render.php
@@ -70,8 +70,8 @@ $nb_separator_class  = $nb_narrow_separator ? '' : 'is-style-wide';
 	<?php endif; ?>
 
 	<div class="wp-block-wp-newsletter-builder-footer__links">
-		<a href="{{unsubscribe}}"><?php esc_html_e( 'Unsubscribe', 'wp-newsletter-builder' ); ?></a>
+		<a href="#unsubscribe"><?php esc_html_e( 'Unsubscribe', 'wp-newsletter-builder' ); ?></a>
 		&nbsp;|&nbsp;
-		<a href="{{unsubscribe_preferences}}"><?php esc_html_e( 'Preferences', 'wp-newsletter-builder' ); ?></a>
+		<a href="#unsubscribe_preferences"><?php esc_html_e( 'Preferences', 'wp-newsletter-builder' ); ?></a>
 	</div>
 </div>

--- a/blocks/footer/render.php
+++ b/blocks/footer/render.php
@@ -9,7 +9,7 @@
  * @package wp-newsletter-builder
  */
 
-$nb_settings         = get_option( 'nb_campaign_monitor_settings' );
+$nb_settings         = get_option( 'nb_settings' );
 $nb_footer_settings  = is_array( $nb_settings ) ? $nb_settings['footer_settings'] : [];
 $nb_facebook_url     = $nb_footer_settings['facebook_url'] ?? '';
 $nb_twitter_url      = $nb_footer_settings['twitter_url'] ?? '';

--- a/blocks/header/render.php
+++ b/blocks/header/render.php
@@ -13,8 +13,8 @@ if ( empty( $wp_newsletter_builder_block_post_id ) ) {
 	return;
 }
 
-$wp_newsletter_builder_block_image_id = get_post_meta( $wp_newsletter_builder_block_post_id, 'nb_newsletter_header_img', true );
-if ( empty( $wp_newsletter_builder_block_image_id ) || ! is_int( $wp_newsletter_builder_block_image_id ) ) {
+$wp_newsletter_builder_block_image_id = (int) get_post_meta( $wp_newsletter_builder_block_post_id, 'nb_newsletter_header_img', true );
+if ( empty( $wp_newsletter_builder_block_image_id ) ) {
 	return;
 }
 // TODO: Add a check to see if the image exists.

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.3.15
+ * Version: 0.3.16
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 6.2

--- a/src/class-ads.php
+++ b/src/class-ads.php
@@ -17,6 +17,14 @@ class Ads {
 	 * @return void
 	 */
 	public function __construct() {
+		/**
+		 * Filter to enable/disable ads support.
+		 */
+		$support_ads = apply_filters( 'wp_newsletter_builder_enable_ads_support', true );
+		if ( ! $support_ads ) {
+			return;
+		}
+
 		add_filter( 'the_content', [ $this, 'insert_ads' ], 8, 1 );
 		add_filter( 'render_block_wp-newsletter-builder/ad', [ $this, 'render_ad' ], 10, 2 );
 		add_filter( 'wp_kses_allowed_html', [ $this, 'modify_allowed_html' ], 10, 2 );

--- a/src/email-providers/class-sendgrid.php
+++ b/src/email-providers/class-sendgrid.php
@@ -161,6 +161,20 @@ class Sendgrid implements Email_Provider {
 			''
 		);
 
+		/**
+		 * Since CSSToInlineStyles strips out {{}} tags, we are settings up some placeholders that
+		 * can be replaced after the conversion.
+		 *
+		 * @link https://github.com/tijsverkoyen/CssToInlineStyles/issues/163
+		 */
+		if ( str_contains( $html_content, 'href="#unsubscribe"' ) ) {
+			$html_content = str_replace( 'href="#unsubscribe"', 'href="{{unsubscribe}}"', $html_content );
+		}
+
+		if ( str_contains( $html_content, 'href="#unsubscribe_preferences"' ) ) {
+			$html_content = str_replace( 'href="#unsubscribe_preferences"', 'href="{{unsubscribe_preferences}}"', $html_content );
+		}
+
 		$text_content = wp_strip_all_tags( $html_content );
 		$subject      = get_post_meta( $newsletter_id, 'nb_newsletter_subject', true );
 

--- a/src/email-providers/class-sendgrid.php
+++ b/src/email-providers/class-sendgrid.php
@@ -189,7 +189,9 @@ class Sendgrid implements Email_Provider {
 		$request_body->email_config->generate_plain_content = true;
 		$request_body->email_config->sender_id              = $sender_id ?? 0;
 		$request_body->email_config->subject                = $subject;
-		$request_body->email_config->suppression_group_id   = (int) get_post_meta( $newsletter_id, 'nb_newsletter_suppression_group', true );
+
+		// TODO: A suppression group id or a custom unsubscribe url should be options.
+		$request_body->email_config->custom_unsubscribe_url = home_url() . '/account';
 
 		$request_body->send_to->list_ids    = $list_ids;
 		$request_body->send_to->segment_ids = [];

--- a/src/email-providers/class-sendgrid.php
+++ b/src/email-providers/class-sendgrid.php
@@ -162,7 +162,7 @@ class Sendgrid implements Email_Provider {
 		);
 
 		/**
-		 * Since CSSToInlineStyles strips out {{}} tags, we are settings up some placeholders that
+		 * Since CSSToInlineStyles strips out {{}} tags, we are settings up placeholders that
 		 * can be replaced after the conversion.
 		 *
 		 * @link https://github.com/tijsverkoyen/CssToInlineStyles/issues/163


### PR DESCRIPTION
## Summary
- Adds in a filter to enable/disable ads support
- Fixes a bug that was causing header images to not display
- Adds in a custom 'Manage Subscription Preferences' link -- in the footer block

## Notes for reviewers
- Issue #135 has been created to allow users to be able to customize the output of the footer block.
- Issue #136 has been created to allow users to be able to configure a suppression group id or a custom unsubscribe url.
- Will bump version after PR has been approved.

## Changelog entries
### Added
- a filter to enable/disable ads
### Changed
- footer markup to allow for a custom subscription management link

### Removed
### Fixed
- header images not displaying
- footer settings not displaying

## Ticket(s)
https://alleyinteractive.atlassian.net/browse/LEDE-2616