### PR TITLE
LEDE-2663, LEDE-2664, LEDE-2649 Modify Block Supports

### DIFF
--- a/block-filters/heading/index.php
+++ b/block-filters/heading/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Adds a separator to a block.
+ * Core heading block modifications.
  *
  * @package wp-newsletter-builder
  */
@@ -24,11 +24,11 @@ function register_heading_scripts(): void {
 add_action( 'init', __NAMESPACE__ . '\register_heading_scripts' );
 
 /**
- * Enqueue block editor assets for separator.
+ * Enqueue block editor assets for heading.
  */
 function action_enqueue_heading_assets(): void {
 	$post_type = get_edit_post_type();
-	if ( 'nb_newsletter' !== $post_type ) {
+	if ( ( 'nb_newsletter' !== $post_type ) && ( 'nb_template' !== $post_type ) ) {
 		return;
 	}
 	wp_enqueue_script( 'plugin-newsletter-heading' );

--- a/block-filters/heading/index.php
+++ b/block-filters/heading/index.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Adds a separator to a block.
+ *
+ * @package wp-newsletter-builder
+ */
+
+namespace WP_Newsletter_Builder;
+
+/**
+ * Registers assets so that they can be enqueued through Gutenberg in
+ * the corresponding context.
+ */
+function register_heading_scripts(): void {
+	wp_register_script(
+		'plugin-newsletter-heading',
+		get_entry_asset_url( 'wp-newsletter-builder-heading' ),
+		get_asset_dependency_array( 'wp-newsletter-builder-heading' ),
+		get_asset_version( 'wp-newsletter-builder-heading' ),
+		true
+	);
+	wp_set_script_translations( 'plugin-newsletter-heading' );
+}
+add_action( 'init', __NAMESPACE__ . '\register_heading_scripts' );
+
+/**
+ * Enqueue block editor assets for separator.
+ */
+function action_enqueue_heading_assets(): void {
+	$post_type = get_edit_post_type();
+	if ( 'nb_newsletter' !== $post_type ) {
+		return;
+	}
+	wp_enqueue_script( 'plugin-newsletter-heading' );
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\action_enqueue_heading_assets' );

--- a/block-filters/heading/index.tsx
+++ b/block-filters/heading/index.tsx
@@ -2,12 +2,11 @@ import { addFilter } from '@wordpress/hooks';
 
 /**
  * Modifies supports for Heading block.
- * https://nickdiego.com/how-to-modify-block-supports-using-client-side-filters/
  *
  * @param {Object} settings - The original block settings.
  * @param {string} name - The name of the block.
  *
- * @returns {Object} The modified block settings with added border support.
+ * @returns {Object} The modified block settings.
  */
 // @ts-ignore
 function modifyHeadingSupports(settings, name) {

--- a/block-filters/heading/index.tsx
+++ b/block-filters/heading/index.tsx
@@ -1,10 +1,8 @@
-/**
- * WordPress dependencies
- */
 import { addFilter } from '@wordpress/hooks';
 
 /**
- * Adds border support to Column, Heading, and Paragraph blocks.
+ * Modifies supports for Heading block.
+ * https://nickdiego.com/how-to-modify-block-supports-using-client-side-filters/
  *
  * @param {Object} settings - The original block settings.
  * @param {string} name - The name of the block.
@@ -12,37 +10,34 @@ import { addFilter } from '@wordpress/hooks';
  * @returns {Object} The modified block settings with added border support.
  */
 // @ts-ignore
-function addBorderSupport(settings, name) {
+function modifyHeadingSupports(settings, name) {
   // Bail early if the block does not have supports.
   if (!settings?.supports) {
-    console.log('here');
     return settings;
   }
-
-  // Only apply to Column, Heading, and Paragraph blocks.
+  // Only apply to Heading blocks.
   if (
     name === 'core/heading'
-    || name === 'core/paragraph'
   ) {
-    console.log('what about here');
     return {
       ...settings,
       supports: Object.assign(settings.supports, {
-        __experimentalBorder: {
-          color: true,
-          style: true,
-          width: true,
-          radius: true,
-          __experimentalDefaultControls: {
-            color: false,
-            style: false,
-            width: false,
-            radius: false,
-          },
-        },
+        align: [],
+        anchor: false,
         color: {
           background: false,
           text: false,
+        },
+        customClassName: false,
+        spacing: false,
+        typography: {
+          __experimentalFontSize: false,
+          __experimentalLineHeight: false,
+          __experimentalLetterSpacing: true,
+          __experimentalFontFamily: false,
+          __experimentalFontWeight: false,
+          __experimentalFontStyle: false,
+          __experimentalTextTransform: true,
         },
       }),
     };
@@ -53,6 +48,6 @@ function addBorderSupport(settings, name) {
 
 addFilter(
   'blocks.registerBlockType',
-  'modify-block-supports/add-border-support',
-  addBorderSupport,
+  'wp-newsletter-builder/heading',
+  modifyHeadingSupports,
 );

--- a/block-filters/heading/index.tsx
+++ b/block-filters/heading/index.tsx
@@ -1,4 +1,5 @@
 import { addFilter } from '@wordpress/hooks';
+// import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Modifies supports for Heading block.
@@ -28,6 +29,7 @@ function modifyHeadingSupports(settings, name) {
           text: false,
         },
         customClassName: false,
+        inserter: false,
         spacing: false,
         typography: {
           __experimentalFontSize: false,
@@ -41,7 +43,6 @@ function modifyHeadingSupports(settings, name) {
       }),
     };
   }
-
   return settings;
 }
 

--- a/block-filters/heading/index.tsx
+++ b/block-filters/heading/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Adds border support to Column, Heading, and Paragraph blocks.
+ *
+ * @param {Object} settings - The original block settings.
+ * @param {string} name - The name of the block.
+ *
+ * @returns {Object} The modified block settings with added border support.
+ */
+// @ts-ignore
+function addBorderSupport(settings, name) {
+  // Bail early if the block does not have supports.
+  if (!settings?.supports) {
+    console.log('here');
+    return settings;
+  }
+
+  // Only apply to Column, Heading, and Paragraph blocks.
+  if (
+    name === 'core/heading'
+    || name === 'core/paragraph'
+  ) {
+    console.log('what about here');
+    return {
+      ...settings,
+      supports: Object.assign(settings.supports, {
+        __experimentalBorder: {
+          color: true,
+          style: true,
+          width: true,
+          radius: true,
+          __experimentalDefaultControls: {
+            color: false,
+            style: false,
+            width: false,
+            radius: false,
+          },
+        },
+        color: {
+          background: false,
+          text: false,
+        },
+      }),
+    };
+  }
+
+  return settings;
+}
+
+addFilter(
+  'blocks.registerBlockType',
+  'modify-block-supports/add-border-support',
+  addBorderSupport,
+);

--- a/block-filters/heading/index.tsx
+++ b/block-filters/heading/index.tsx
@@ -1,5 +1,4 @@
 import { addFilter } from '@wordpress/hooks';
-// import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Modifies supports for Heading block.

--- a/block-filters/list/index.php
+++ b/block-filters/list/index.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Core list and list item block modifications.
+ *
+ * @package wp-newsletter-builder
+ */
+
+namespace WP_Newsletter_Builder;
+
+/**
+ * Registers assets so that they can be enqueued through Gutenberg in
+ * the corresponding context.
+ */
+function register_list_scripts(): void {
+	wp_register_script(
+		'plugin-newsletter-list',
+		get_entry_asset_url( 'wp-newsletter-builder-list' ),
+		get_asset_dependency_array( 'wp-newsletter-builder-list' ),
+		get_asset_version( 'wp-newsletter-builder-list' ),
+		true
+	);
+	wp_set_script_translations( 'plugin-newsletter-list' );
+}
+add_action( 'init', __NAMESPACE__ . '\register_list_scripts' );
+
+/**
+ * Enqueue block editor assets for lists.
+ */
+function action_enqueue_list_assets(): void {
+	$post_type = get_edit_post_type();
+	if ( ( 'nb_newsletter' !== $post_type ) && ( 'nb_template' !== $post_type ) ) {
+		return;
+	}
+	wp_enqueue_script( 'plugin-newsletter-list' );
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\action_enqueue_list_assets' );

--- a/block-filters/list/index.tsx
+++ b/block-filters/list/index.tsx
@@ -2,12 +2,11 @@ import { addFilter } from '@wordpress/hooks';
 
 /**
  * Modifies supports for List block.
- * https://nickdiego.com/how-to-modify-block-supports-using-client-side-filters/
  *
  * @param {Object} settings - The original block settings.
  * @param {string} name - The name of the block.
  *
- * @returns {Object} The modified block settings with added border support.
+ * @returns {Object} The modified block settings.
  */
 // @ts-ignore
 function modifyListSupports(settings, name) {

--- a/block-filters/list/index.tsx
+++ b/block-filters/list/index.tsx
@@ -1,7 +1,7 @@
 import { addFilter } from '@wordpress/hooks';
 
 /**
- * Modifies supports for Paragraph block.
+ * Modifies supports for List block.
  * https://nickdiego.com/how-to-modify-block-supports-using-client-side-filters/
  *
  * @param {Object} settings - The original block settings.
@@ -10,14 +10,15 @@ import { addFilter } from '@wordpress/hooks';
  * @returns {Object} The modified block settings with added border support.
  */
 // @ts-ignore
-function modifyParagraphSupports(settings, name) {
+function modifyListSupports(settings, name) {
   // Bail early if the block does not have supports.
   if (!settings?.supports) {
     return settings;
   }
-  // Only apply to paragraph blocks.
+  // Only apply to list and list item blocks.
   if (
-    name === 'core/paragraph'
+    name === 'core/list'
+    || name === 'core/list-item'
   ) {
     return {
       ...settings,
@@ -48,6 +49,6 @@ function modifyParagraphSupports(settings, name) {
 
 addFilter(
   'blocks.registerBlockType',
-  'wp-newsletter-builder/paragraph',
-  modifyParagraphSupports,
+  'wp-newsletter-builder/list',
+  modifyListSupports,
 );

--- a/block-filters/list/index.tsx
+++ b/block-filters/list/index.tsx
@@ -29,6 +29,7 @@ function modifyListSupports(settings, name) {
           text: false,
         },
         customClassName: false,
+        inserter: false,
         spacing: false,
         typography: {
           __experimentalFontSize: false,

--- a/block-filters/paragraph/index.php
+++ b/block-filters/paragraph/index.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Core paragraph block modifications.
+ *
+ * @package wp-newsletter-builder
+ */
+
+namespace WP_Newsletter_Builder;
+
+/**
+ * Registers assets so that they can be enqueued through Gutenberg in
+ * the corresponding context.
+ */
+function register_paragraph_scripts(): void {
+	wp_register_script(
+		'plugin-newsletter-paragraph',
+		get_entry_asset_url( 'wp-newsletter-builder-paragraph' ),
+		get_asset_dependency_array( 'wp-newsletter-builder-paragraph' ),
+		get_asset_version( 'wp-newsletter-builder-paragraph' ),
+		true
+	);
+	wp_set_script_translations( 'plugin-newsletter-paragraph' );
+}
+add_action( 'init', __NAMESPACE__ . '\register_paragraph_scripts' );
+
+/**
+ * Enqueue block editor assets for paragraph.
+ */
+function action_enqueue_paragraph_assets(): void {
+	$post_type = get_edit_post_type();
+	if ( ( 'nb_newsletter' !== $post_type ) && ( 'nb_template' !== $post_type ) ) {
+		return;
+	}
+	wp_enqueue_script( 'plugin-newsletter-paragraph' );
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\action_enqueue_paragraph_assets' );

--- a/block-filters/paragraph/index.tsx
+++ b/block-filters/paragraph/index.tsx
@@ -1,0 +1,54 @@
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Modifies supports for Paragraph block.
+ * https://nickdiego.com/how-to-modify-block-supports-using-client-side-filters/
+ *
+ * @param {Object} settings - The original block settings.
+ * @param {string} name - The name of the block.
+ *
+ * @returns {Object} The modified block settings with added border support.
+ */
+// @ts-ignore
+function modifyParagraphSupports(settings, name) {
+  // Bail early if the block does not have supports.
+  if (!settings?.supports) {
+    return settings;
+  }
+  // Only apply to paragraph blocks.
+  if (
+    name === 'core/paragraph'
+  ) {
+    return {
+      ...settings,
+      supports: Object.assign(settings.supports, {
+        align: [],
+        anchor: false,
+        color: {
+          background: false,
+          text: false,
+        },
+        customClassName: false,
+        spacing: false,
+        typography: {
+          __experimentalFontSize: false,
+          __experimentalLineHeight: false,
+          __experimentalLetterSpacing: true,
+          __experimentalFontFamily: false,
+          __experimentalFontWeight: false,
+          __experimentalFontStyle: false,
+          __experimentalTextTransform: true,
+          __experimentalDropCap: false,
+        },
+      }),
+    };
+  }
+
+  return settings;
+}
+
+addFilter(
+  'blocks.registerBlockType',
+  'wp-newsletter-builder/paragraph',
+  modifyParagraphSupports,
+);

--- a/block-filters/paragraph/index.tsx
+++ b/block-filters/paragraph/index.tsx
@@ -2,12 +2,11 @@ import { addFilter } from '@wordpress/hooks';
 
 /**
  * Modifies supports for Paragraph block.
- * https://nickdiego.com/how-to-modify-block-supports-using-client-side-filters/
  *
  * @param {Object} settings - The original block settings.
  * @param {string} name - The name of the block.
  *
- * @returns {Object} The modified block settings with added border support.
+ * @returns {Object} The modified block settings.
  */
 // @ts-ignore
 function modifyParagraphSupports(settings, name) {

--- a/block-filters/paragraph/index.tsx
+++ b/block-filters/paragraph/index.tsx
@@ -28,6 +28,7 @@ function modifyParagraphSupports(settings, name) {
           text: false,
         },
         customClassName: false,
+        inserter: false,
         spacing: false,
         typography: {
           __experimentalFontSize: false,

--- a/blocks/divider/render.php
+++ b/blocks/divider/render.php
@@ -12,4 +12,5 @@
 $wp_newsletter_builder_divider_height = $attributes['elHeight'] ?? null;
 $wp_newsletter_builder_divider_color  = $attributes['elColor'] ?? null; 
 ?>
+
 <div style="height: <?php echo esc_attr( $wp_newsletter_builder_divider_height ); ?>px;background-color: <?php echo esc_attr( $wp_newsletter_builder_divider_color ); ?>;"></div>

--- a/blocks/heading/block.json
+++ b/blocks/heading/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wp-newsletter-builder/heading",
+	"version": "0.1.0",
+	"title": "Newsletter Heading",
+	"category": "text",
+	"icon": "heading",
+	"description": "Heading wrapper that provides email-friendly enhancements",
+	"textdomain": "heading",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
+	"render": "file:render.php",
+	"attributes": {
+		"elColor": {
+			"type": "string",
+			"default": "#000"
+		}
+	}
+}

--- a/blocks/heading/edit.tsx
+++ b/blocks/heading/edit.tsx
@@ -1,0 +1,73 @@
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { useBlockProps, InspectorControls, InnerBlocks } from '@wordpress/block-editor';
+import { ColorPicker, PanelBody } from '@wordpress/components';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * Those files can contain any CSS code that gets applied to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+// Uncomment this line if you want to import a CSS file for this block.
+// import './index.scss';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+interface EditProps {
+  attributes: {
+    elColor?: string;
+  };
+  setAttributes: (attributes: {}) => void;
+}
+
+export default function Edit({
+  attributes: {
+    elColor = '#000',
+  },
+  setAttributes,
+}: EditProps) {
+  const TEMPLATE = [['core/heading']];
+  const headingStyles = {
+    color: elColor,
+  };
+
+  return (
+    <>
+      <InspectorControls>
+        <PanelBody title="Heading Color">
+          <h3>{__('Text color', 'wp-newsletter-builder')}</h3>
+          {/* Using ColorPicker instead of ColorPalette to ensure email-friendly values. */}
+          <ColorPicker
+            color={elColor}
+            onChange={(color) => setAttributes({ elColor: color })}
+          />
+        </PanelBody>
+      </InspectorControls>
+      <div {...useBlockProps({ className: 'newsletter-heading', style: headingStyles })}>
+        <InnerBlocks
+          // @ts-ignore
+          template={TEMPLATE}
+          templateLock="all"
+        />
+      </div>
+    </>
+  );
+}

--- a/blocks/heading/index.php
+++ b/blocks/heading/index.php
@@ -12,11 +12,10 @@
  *
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
-function heading_heading_block_init() {
+function wp_newsletter_builder_heading_block_init() {
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__
 	);
-
 }
-add_action( 'init', 'heading_heading_block_init' );
+add_action( 'init', 'wp_newsletter_builder_heading_block_init' );

--- a/blocks/heading/index.php
+++ b/blocks/heading/index.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Block Name: Newsletter Heading.
+ *
+ * @package wp-newsletter-builder
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function heading_heading_block_init() {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__
+	);
+
+}
+add_action( 'init', 'heading_heading_block_init' );

--- a/blocks/heading/index.tsx
+++ b/blocks/heading/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+// Uncomment this line if you want to import a CSS file for this block.
+// import './style.scss';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType(
+  /* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+  metadata,
+  {
+    apiVersion: 2,
+    edit,
+    save: () => {
+      const blockProps = useBlockProps.save();
+      return (
+        <div {...blockProps}>
+          {/* @ts-ignore */}
+          <InnerBlocks.Content />
+        </div>
+      );
+    },
+    title: metadata.title,
+  },
+);

--- a/blocks/heading/render.php
+++ b/blocks/heading/render.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * All of the parameters passed to the function where this file is being required are accessible in this scope:
+ *
+ * @param array    $attributes     The array of attributes for this block.
+ * @param string   $content        Rendered block output. ie. <InnerBlocks.Content />.
+ * @param WP_Block $block_instance The instance of the WP_Block class that represents the block being rendered.
+ *
+ * @package wp-newsletter-builder
+ */
+
+$wp_newsletter_builder_heading_color  = $attributes['elColor'] ?? null;
+?>
+<div style="color: <?php echo esc_attr( $wp_newsletter_builder_heading_color ); ?>;" ?>
+	<?php echo wp_kses_post( $content ?? '' ); ?>
+</div>

--- a/blocks/heading/render.php
+++ b/blocks/heading/render.php
@@ -9,7 +9,7 @@
  * @package wp-newsletter-builder
  */
 
-$wp_newsletter_builder_heading_color = $attributes['elColor'] ?? null;
+$wp_newsletter_builder_heading_color = $attributes['elColor'] ?? '';
 ?>
 <div style="color: <?php echo esc_attr( $wp_newsletter_builder_heading_color ); ?>;" ?>
 	<?php echo wp_kses_post( $content ?? '' ); ?>

--- a/blocks/heading/render.php
+++ b/blocks/heading/render.php
@@ -9,7 +9,7 @@
  * @package wp-newsletter-builder
  */
 
-$wp_newsletter_builder_heading_color  = $attributes['elColor'] ?? null;
+$wp_newsletter_builder_heading_color = $attributes['elColor'] ?? null;
 ?>
 <div style="color: <?php echo esc_attr( $wp_newsletter_builder_heading_color ); ?>;" ?>
 	<?php echo wp_kses_post( $content ?? '' ); ?>

--- a/blocks/list/block.json
+++ b/blocks/list/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wp-newsletter-builder/list",
+	"version": "0.1.0",
+	"title": "Newsletter List",
+	"category": "text",
+	"icon": "editor-ul",
+	"description": "List wrapper that provides email-friendly enhancements",
+	"textdomain": "list",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
+	"render": "file:render.php",
+	"attributes": {
+		"elColor": {
+			"type": "string",
+			"default": "#000"
+		}
+	}
+}

--- a/blocks/list/edit.tsx
+++ b/blocks/list/edit.tsx
@@ -1,0 +1,73 @@
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { useBlockProps, InspectorControls, InnerBlocks } from '@wordpress/block-editor';
+import { ColorPicker, PanelBody } from '@wordpress/components';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * Those files can contain any CSS code that gets applied to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+// Uncomment this line if you want to import a CSS file for this block.
+// import './index.scss';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+interface EditProps {
+  attributes: {
+    elColor?: string;
+  };
+  setAttributes: (attributes: {}) => void;
+}
+
+export default function Edit({
+  attributes: {
+    elColor = '#000',
+  },
+  setAttributes,
+}: EditProps) {
+  const TEMPLATE = [['core/list']];
+  const listStyles = {
+    color: elColor,
+  };
+
+  return (
+    <>
+      <InspectorControls>
+        <PanelBody title="List Color">
+          <h3>{__('Text color', 'wp-newsletter-builder')}</h3>
+          {/* Using ColorPicker instead of ColorPalette to ensure email-friendly values. */}
+          <ColorPicker
+            color={elColor}
+            onChange={(color) => setAttributes({ elColor: color })}
+          />
+        </PanelBody>
+      </InspectorControls>
+      <div {...useBlockProps({ className: 'newsletter-list', style: listStyles })}>
+        <InnerBlocks
+          // @ts-ignore
+          template={TEMPLATE}
+          templateLock="all"
+        />
+      </div>
+    </>
+  );
+}

--- a/blocks/list/index.php
+++ b/blocks/list/index.php
@@ -12,11 +12,11 @@
  *
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
-function list_list_block_init() {
+function wp_newsletter_builder_list_block_init() {
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__
 	);
 
 }
-add_action( 'init', 'list_list_block_init' );
+add_action( 'init', 'wp_newsletter_builder_list_block_init' );

--- a/blocks/list/index.php
+++ b/blocks/list/index.php
@@ -17,6 +17,5 @@ function wp_newsletter_builder_list_block_init() {
 	register_block_type(
 		__DIR__
 	);
-
 }
 add_action( 'init', 'wp_newsletter_builder_list_block_init' );

--- a/blocks/list/index.php
+++ b/blocks/list/index.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Block Name: Newsletter List.
+ *
+ * @package wp-newsletter-builder
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function list_list_block_init() {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__
+	);
+
+}
+add_action( 'init', 'list_list_block_init' );

--- a/blocks/list/index.tsx
+++ b/blocks/list/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+// Uncomment this line if you want to import a CSS file for this block.
+// import './style.scss';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType(
+  /* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+  metadata,
+  {
+    apiVersion: 2,
+    edit,
+    save: () => {
+      const blockProps = useBlockProps.save();
+      return (
+        <div {...blockProps}>
+          {/* @ts-ignore */}
+          <InnerBlocks.Content />
+        </div>
+      );
+    },
+    title: metadata.title,
+  },
+);

--- a/blocks/list/render.php
+++ b/blocks/list/render.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * All of the parameters passed to the function where this file is being required are accessible in this scope:
+ *
+ * @param array    $attributes     The array of attributes for this block.
+ * @param string   $content        Rendered block output. ie. <InnerBlocks.Content />.
+ * @param WP_Block $block_instance The instance of the WP_Block class that represents the block being rendered.
+ *
+ * @package wp-newsletter-builder
+ */
+$wp_newsletter_builder_list_color  = $attributes['elColor'] ?? null;
+?>
+<div style="color: <?php echo esc_attr( $wp_newsletter_builder_list_color ); ?>;" ?>
+	<?php echo wp_kses_post( $content ?? '' ); ?>
+</div>

--- a/blocks/list/render.php
+++ b/blocks/list/render.php
@@ -10,6 +10,7 @@
  */
 $wp_newsletter_builder_list_color = $attributes['elColor'] ?? null;
 ?>
+
 <div style="color: <?php echo esc_attr( $wp_newsletter_builder_list_color ); ?>;" ?>
 	<?php echo wp_kses_post( $content ?? '' ); ?>
 </div>

--- a/blocks/list/render.php
+++ b/blocks/list/render.php
@@ -9,7 +9,7 @@
  * @package wp-newsletter-builder
  */
 
-$wp_newsletter_builder_list_color = $attributes['elColor'] ?? null;
+$wp_newsletter_builder_list_color = $attributes['elColor'] ?? '';
 ?>
 
 <div style="color: <?php echo esc_attr( $wp_newsletter_builder_list_color ); ?>;" ?>

--- a/blocks/list/render.php
+++ b/blocks/list/render.php
@@ -8,6 +8,7 @@
  *
  * @package wp-newsletter-builder
  */
+
 $wp_newsletter_builder_list_color = $attributes['elColor'] ?? null;
 ?>
 

--- a/blocks/list/render.php
+++ b/blocks/list/render.php
@@ -8,7 +8,7 @@
  *
  * @package wp-newsletter-builder
  */
-$wp_newsletter_builder_list_color  = $attributes['elColor'] ?? null;
+$wp_newsletter_builder_list_color = $attributes['elColor'] ?? null;
 ?>
 <div style="color: <?php echo esc_attr( $wp_newsletter_builder_list_color ); ?>;" ?>
 	<?php echo wp_kses_post( $content ?? '' ); ?>

--- a/blocks/paragraph/block.json
+++ b/blocks/paragraph/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wp-newsletter-builder/paragraph",
+	"version": "0.1.0",
+	"title": "Newsletter Paragraph",
+	"category": "text",
+	"icon": "editor-paragraph",
+	"description": "Paragraph wrapper that provides email-friendly enhancements",
+	"textdomain": "paragraph",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
+	"render": "file:render.php",
+	"attributes": {
+		"elColor": {
+			"type": "string",
+			"default": "#000"
+		}
+	}
+}

--- a/blocks/paragraph/edit.tsx
+++ b/blocks/paragraph/edit.tsx
@@ -1,0 +1,73 @@
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { useBlockProps, InspectorControls, InnerBlocks } from '@wordpress/block-editor';
+import { ColorPicker, PanelBody } from '@wordpress/components';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * Those files can contain any CSS code that gets applied to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+// Uncomment this line if you want to import a CSS file for this block.
+// import './index.scss';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+interface EditProps {
+  attributes: {
+    elColor?: string;
+  };
+  setAttributes: (attributes: {}) => void;
+}
+
+export default function Edit({
+  attributes: {
+    elColor = '#000',
+  },
+  setAttributes,
+}: EditProps) {
+  const TEMPLATE = [['core/paragraph']];
+  const paragraphStyles = {
+    color: elColor,
+  };
+
+  return (
+    <>
+      <InspectorControls>
+        <PanelBody title="Paragraph Color">
+          <h3>{__('Text color', 'wp-newsletter-builder')}</h3>
+          {/* Using ColorPicker instead of ColorPalette to ensure email-friendly values. */}
+          <ColorPicker
+            color={elColor}
+            onChange={(color) => setAttributes({ elColor: color })}
+          />
+        </PanelBody>
+      </InspectorControls>
+      <div {...useBlockProps({ className: 'newsletter-paragraph', style: paragraphStyles })}>
+        <InnerBlocks
+          // @ts-ignore
+          template={TEMPLATE}
+          templateLock="all"
+        />
+      </div>
+    </>
+  );
+}

--- a/blocks/paragraph/index.php
+++ b/blocks/paragraph/index.php
@@ -12,11 +12,11 @@
  *
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
-function paragraph_paragraph_block_init() {
+function wp_newsletter_builder_paragraph_block_init() {
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__
 	);
 
 }
-add_action( 'init', 'paragraph_paragraph_block_init' );
+add_action( 'init', 'wp_newsletter_builder_paragraph_block_init' );

--- a/blocks/paragraph/index.php
+++ b/blocks/paragraph/index.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Block Name: Newsletter Paragraph.
+ *
+ * @package wp-newsletter-builder
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function paragraph_paragraph_block_init() {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__
+	);
+
+}
+add_action( 'init', 'paragraph_paragraph_block_init' );

--- a/blocks/paragraph/index.php
+++ b/blocks/paragraph/index.php
@@ -17,6 +17,5 @@ function wp_newsletter_builder_paragraph_block_init() {
 	register_block_type(
 		__DIR__
 	);
-
 }
 add_action( 'init', 'wp_newsletter_builder_paragraph_block_init' );

--- a/blocks/paragraph/index.tsx
+++ b/blocks/paragraph/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+// Uncomment this line if you want to import a CSS file for this block.
+// import './style.scss';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType(
+  /* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+  metadata,
+  {
+    apiVersion: 2,
+    edit,
+    save: () => {
+      const blockProps = useBlockProps.save();
+      return (
+        <div {...blockProps}>
+          {/* @ts-ignore */}
+          <InnerBlocks.Content />
+        </div>
+      );
+    },
+    title: metadata.title,
+  },
+);

--- a/blocks/paragraph/render.php
+++ b/blocks/paragraph/render.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * All of the parameters passed to the function where this file is being required are accessible in this scope:
+ *
+ * @param array    $attributes     The array of attributes for this block.
+ * @param string   $content        Rendered block output. ie. <InnerBlocks.Content />.
+ * @param WP_Block $block_instance The instance of the WP_Block class that represents the block being rendered.
+ *
+ * @package wp-newsletter-builder
+ */
+$wp_newsletter_builder_paragraph_color  = $attributes['elColor'] ?? null;
+?>
+<div style="color: <?php echo esc_attr( $wp_newsletter_builder_paragraph_color ); ?>;" ?>
+	<?php echo wp_kses_post( $content ?? '' ); ?>
+</div>

--- a/blocks/paragraph/render.php
+++ b/blocks/paragraph/render.php
@@ -11,6 +11,7 @@
 
 $wp_newsletter_builder_paragraph_color = $attributes['elColor'] ?? null;
 ?>
+
 <div style="color: <?php echo esc_attr( $wp_newsletter_builder_paragraph_color ); ?>;" ?>
 	<?php echo wp_kses_post( $content ?? '' ); ?>
 </div>

--- a/blocks/paragraph/render.php
+++ b/blocks/paragraph/render.php
@@ -9,7 +9,7 @@
  * @package wp-newsletter-builder
  */
 
-$wp_newsletter_builder_paragraph_color = $attributes['elColor'] ?? null;
+$wp_newsletter_builder_paragraph_color = $attributes['elColor'] ?? '';
 ?>
 
 <div style="color: <?php echo esc_attr( $wp_newsletter_builder_paragraph_color ); ?>;" ?>

--- a/blocks/paragraph/render.php
+++ b/blocks/paragraph/render.php
@@ -8,7 +8,8 @@
  *
  * @package wp-newsletter-builder
  */
-$wp_newsletter_builder_paragraph_color  = $attributes['elColor'] ?? null;
+
+$wp_newsletter_builder_paragraph_color = $attributes['elColor'] ?? null;
 ?>
 <div style="color: <?php echo esc_attr( $wp_newsletter_builder_paragraph_color ); ?>;" ?>
 	<?php echo wp_kses_post( $content ?? '' ); ?>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13116,11 +13116,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -17050,9 +17050,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },

--- a/plugin.php
+++ b/plugin.php
@@ -51,6 +51,7 @@ require_once __DIR__ . '/src/meta.php';
 require_once __DIR__ . '/src/utils.php';
 require_once __DIR__ . '/block-filters/separator/index.php';
 require_once __DIR__ . '/block-filters/heading/index.php';
+require_once __DIR__ . '/block-filters/paragraph/index.php';
 require_once __DIR__ . '/plugins/newsletter-from-post/index.php';
 require_once __DIR__ . '/plugins/newsletter-status/index.php';
 

--- a/plugin.php
+++ b/plugin.php
@@ -52,6 +52,7 @@ require_once __DIR__ . '/src/utils.php';
 require_once __DIR__ . '/block-filters/separator/index.php';
 require_once __DIR__ . '/block-filters/heading/index.php';
 require_once __DIR__ . '/block-filters/paragraph/index.php';
+require_once __DIR__ . '/block-filters/list/index.php';
 require_once __DIR__ . '/plugins/newsletter-from-post/index.php';
 require_once __DIR__ . '/plugins/newsletter-status/index.php';
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.3.18
+ * Version: 0.3.19
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 6.2

--- a/plugin.php
+++ b/plugin.php
@@ -50,7 +50,7 @@ require_once __DIR__ . '/src/assets.php';
 require_once __DIR__ . '/src/meta.php';
 require_once __DIR__ . '/src/utils.php';
 require_once __DIR__ . '/block-filters/separator/index.php';
-
+require_once __DIR__ . '/block-filters/heading/index.php';
 require_once __DIR__ . '/plugins/newsletter-from-post/index.php';
 require_once __DIR__ . '/plugins/newsletter-status/index.php';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = (env, { mode }) => ({
         }, {
           // All other custom entry points can be included here.
           'wp-newsletter-builder-separator/index': './block-filters/separator',
+          'wp-newsletter-builder-heading/index': './block-filters/heading',
           'wp-newsletter-builder-from-post/index': './plugins/newsletter-from-post',
           'newsletter-status/index': './plugins/newsletter-status',
         }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = (env, { mode }) => ({
           // All other custom entry points can be included here.
           'wp-newsletter-builder-separator/index': './block-filters/separator',
           'wp-newsletter-builder-heading/index': './block-filters/heading',
+          'wp-newsletter-builder-paragraph/index': './block-filters/paragraph',
           'wp-newsletter-builder-from-post/index': './plugins/newsletter-from-post',
           'newsletter-status/index': './plugins/newsletter-status',
         }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = (env, { mode }) => ({
           'wp-newsletter-builder-separator/index': './block-filters/separator',
           'wp-newsletter-builder-heading/index': './block-filters/heading',
           'wp-newsletter-builder-paragraph/index': './block-filters/paragraph',
+          'wp-newsletter-builder-list/index': './block-filters/list',
           'wp-newsletter-builder-from-post/index': './plugins/newsletter-from-post',
           'newsletter-status/index': './plugins/newsletter-status',
         }),


### PR DESCRIPTION
## Summary
Customizes the setting supports for the core paragraph, heading, list, and list-item blocks and adds wrapper components for those blocks so that we can customize inline styles with email-friendly values.

## Notes for reviewers
* Uses existing work in the repo for the separator block as a model as well as [this model](https://nickdiego.com/how-to-modify-block-supports-using-client-side-filters/) by Nick Diego
* I could have made one file that modifies the same supports for all of the text blocks but I chose to keep them separate for maintainability / readability 
* Fixed an issue in node modules -- just used `npm audit fix` -- that was causing a test failure
* Version bump

## Ticket
https://alleyinteractive.atlassian.net/browse/LEDE-2649
https://alleyinteractive.atlassian.net/browse/LEDE-2663
https://alleyinteractive.atlassian.net/browse/LEDE-2644