### PR TITLE
LEDE-2719: Update Newsletter Builder Version + Minor Fixes

### DIFF
--- a/blocks/button/index.php
+++ b/blocks/button/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_button_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'button' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/divider/index.php
+++ b/blocks/divider/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_divider_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'divider' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/email-settings/edit.tsx
+++ b/blocks/email-settings/edit.tsx
@@ -188,6 +188,7 @@ export default function Edit() {
           value={suppressionGroup}
           options={suppressionLists.map((item) => ({ label: item.Name, value: item.ListID }))}
           onChange={(newValue: string) => setMeta({ nb_newsletter_suppression_group: newValue })}
+          required
         />
       ) : (
         /* @ts-ignore */

--- a/blocks/email-settings/index.php
+++ b/blocks/email-settings/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_email_settings_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'email-settings' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/footer/index.php
+++ b/blocks/footer/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_footer_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'footer' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/header/index.php
+++ b/blocks/header/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_header_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'header' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/heading/index.php
+++ b/blocks/heading/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_heading_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'heading' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/list/index.php
+++ b/blocks/list/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_list_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'list' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/paragraph/index.php
+++ b/blocks/paragraph/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_paragraph_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'paragraph' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/post-byline/index.php
+++ b/blocks/post-byline/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_post_byline_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'post-byline' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/post-content/index.php
+++ b/blocks/post-content/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_post_content_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'post-content' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/post-excerpt/index.php
+++ b/blocks/post-excerpt/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_post_excerpt_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'post-excerpt' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/post-featured-image/index.php
+++ b/blocks/post-featured-image/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_post_featured_image_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'post-featured-image' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/post-item/index.php
+++ b/blocks/post-item/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_post_item_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'post-item' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/post-read-more/index.php
+++ b/blocks/post-read-more/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_post_read_more_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'post-read-more' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/post-title/index.php
+++ b/blocks/post-title/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_post_title_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'post-title' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/post/index.php
+++ b/blocks/post/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_post_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'post' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/section/index.php
+++ b/blocks/section/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_section_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'section' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/blocks/two-up-post/index.php
+++ b/blocks/two-up-post/index.php
@@ -13,15 +13,6 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function wp_newsletter_builder_two_up_post_block_init(): void {
-	/**
-	 * Filters whether to register the block.
-	 *
-	 * @param bool   $register Whether to register the block. Default true.
-	 * @param string $name     Block name.
-	 */
-	if ( ! apply_filters( 'wp_newsletter_builder_register_block', true, 'two-up-post' ) ) {
-		return;
-	}
 	// Register the block by passing the location of block.json.
 	register_block_type(
 		__DIR__

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Newsletter Builder
  * Plugin URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Description: Interface to manage email newsletters
- * Version: 0.4.1
+ * Version: 0.4.2
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-newsletter-builder
  * Requires at least: 6.2

--- a/plugins/pre-publish-checks/pre-publish-panel.tsx
+++ b/plugins/pre-publish-checks/pre-publish-panel.tsx
@@ -1,24 +1,40 @@
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { usePostMetaValue } from '@alleyinteractive/block-editor-tools';
+
+const SUPPRESSION_ID_LOCK = 'suppression-group-id-lock';
+const TITLE_LOCK = 'title-empty-lock';
 
 function PrePublishPanel() {
   // @ts-ignore
   const postTitle = useSelect((select) => select('core/editor').getEditedPostAttribute('title'));
+  const [supressionGroupId] = usePostMetaValue('nb_newsletter_suppression_group');
   const isTitleOk = postTitle.trim().length > 0;
 
   const { lockPostSaving, unlockPostSaving } = useDispatch('core/editor');
   const { createWarningNotice, removeNotice } = useDispatch('core/notices');
 
   if (!isTitleOk) {
-    lockPostSaving('title-empty-lock');
+    lockPostSaving(TITLE_LOCK);
     createWarningNotice(
       __('Please enter a newsletter title before publishing.', 'wp-newsletter-builder'),
-      { id: 'title-empty-lock', isDismissible: false },
+      { id: TITLE_LOCK, isDismissible: false },
     );
   } else {
-    unlockPostSaving('title-empty-lock');
-    removeNotice('title-empty-lock');
+    unlockPostSaving(TITLE_LOCK);
+    removeNotice(TITLE_LOCK);
+  }
+
+  if (!supressionGroupId) {
+    lockPostSaving(SUPPRESSION_ID_LOCK);
+    createWarningNotice(
+      __('Please select a suppression group before publishing.', 'wp-newsletter-builder'),
+      { id: SUPPRESSION_ID_LOCK, isDismissible: false },
+    );
+  } else {
+    unlockPostSaving(SUPPRESSION_ID_LOCK);
+    removeNotice(SUPPRESSION_ID_LOCK);
   }
 
   return (
@@ -30,6 +46,11 @@ function PrePublishPanel() {
         {isTitleOk
           ? __('All headline requirements are met.', 'wp-newsletter-builder')
           : __('Headline is required before publishing.', 'wp-newsletter-builder')}
+      </p>
+      <p>
+        {supressionGroupId
+          ? __('Suppression group selected.', 'wp-newsletter-builder')
+          : __('Suppression group is required before publishing.', 'wp-newsletter-builder')}
       </p>
     </PluginPrePublishPanel>
   );

--- a/src/class-block-modifications.php
+++ b/src/class-block-modifications.php
@@ -18,7 +18,6 @@ class Block_Modifications {
 	 */
 	public function __construct() {
 		add_filter( 'pre_render_block', [ $this, 'pre_render_post_block' ], 10, 2 );
-		add_filter( 'wp_newsletter_builder_register_block', [ $this, 'filter_wp_newsletter_builder_register_block' ], 10, 1 );
 	}
 
 	/**
@@ -56,25 +55,5 @@ class Block_Modifications {
 			}
 		}
 		return $block_content;
-	}
-
-	/**
-	 * Filters whether to register a block.
-	 *
-	 * @param boolean $register Current register status.
-	 * @return boolean
-	 */
-	public function filter_wp_newsletter_builder_register_block( bool $register ): bool {
-		$post_type = isset( $_GET['post'] ) ? get_post_type( intval( $_GET['post'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( empty( $post_type ) && isset( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$post_type = sanitize_text_field( $_GET['post_type'] ) ?? 'post'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		}
-		if ( empty( $post_type ) ) {
-			$post_type = 'post';
-		}
-		if ( 'nb_newsletter' !== $post_type && 'nb_template' !== $post_type ) {
-			return false;
-		}
-		return $register;
 	}
 }

--- a/src/class-block-modifications.php
+++ b/src/class-block-modifications.php
@@ -65,21 +65,12 @@ class Block_Modifications {
 	 * @return boolean
 	 */
 	public function filter_wp_newsletter_builder_register_block( bool $register ): bool {
-		global $pagenow;
-
-		$post_id = get_the_ID();
-		if ( empty( $post_id ) ) {
-			$post_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		}
-		$post_type = isset( $_GET['post'] ) ? get_post_type( $post_id ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_type = isset( $_GET['post'] ) ? get_post_type( intval( $_GET['post'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( empty( $post_type ) && isset( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$post_type = sanitize_text_field( $_GET['post_type'] ) ?? 'post'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
-		if ( 'post-new.php' === $pagenow && empty( $post_type ) ) {
-			$post_type = 'post';
-		}
 		if ( empty( $post_type ) ) {
-			return $register;
+			$post_type = 'post';
 		}
 		if ( 'nb_newsletter' !== $post_type && 'nb_template' !== $post_type ) {
 			return false;

--- a/src/email-providers/class-sendgrid.php
+++ b/src/email-providers/class-sendgrid.php
@@ -191,7 +191,7 @@ class Sendgrid implements Email_Provider {
 		$request_body->email_config->subject                = $subject;
 
 		// TODO: A suppression group id or a custom unsubscribe url should be options.
-		$request_body->email_config->custom_unsubscribe_url = home_url() . '/account';
+		$request_body->email_config->custom_unsubscribe_url = home_url() . '/account#panel-1-newsletters';
 
 		$request_body->send_to->list_ids    = $list_ids;
 		$request_body->send_to->segment_ids = [];

--- a/src/email-providers/class-sendgrid.php
+++ b/src/email-providers/class-sendgrid.php
@@ -189,9 +189,7 @@ class Sendgrid implements Email_Provider {
 		$request_body->email_config->generate_plain_content = true;
 		$request_body->email_config->sender_id              = $sender_id ?? 0;
 		$request_body->email_config->subject                = $subject;
-
-		// TODO: A suppression group id or a custom unsubscribe url should be options.
-		$request_body->email_config->custom_unsubscribe_url = home_url() . '/account#panel-1-newsletters';
+		$request_body->email_config->suppression_group_id   = (int) get_post_meta( $newsletter_id, 'nb_newsletter_suppression_group', true );
 
 		$request_body->send_to->list_ids    = $list_ids;
 		$request_body->send_to->segment_ids = [];


### PR DESCRIPTION

Update Newsletter Builder Version + Minor Fixes

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed
- The Manage Sub Preferences redirect in Newsletter Builder to bring the user directly to the Newsletters tab. (/account#newsletters)
- Ensure template styles are displaying as expected in new Newsletters in the Editor before the newsletter is published.
- Update the NB version on Lede to the latest version (0.4.2)

### Deprecated

### Removed
- Remove the “bad stuff” from the 0.4.1 PR

### Fixed

### Security

## Ticket(s)
